### PR TITLE
URL modification to worker docs

### DIFF
--- a/docs/tutorial/worker.md
+++ b/docs/tutorial/worker.md
@@ -54,14 +54,15 @@ Lets consider that controller - 'UserController' is associated with path '/user'
 
 So what these decorators - `Worker` and `DefaultWorker` do ?
 
-* **Worker** - method having decorator Worker is added to route with all http methods (GET,POST etc).And the route is '/${method_name}'. For our example - route will be : '/getuser'.
+* **Worker** - method having decorator Worker is added to route with all http methods (GET,POST etc).And the route is ```'/${method_name}'. For our example - route will be : ```'/getuser'```.
 
 * **DefaultWorker** - method having decorator DefaultWorker is added to route with one http method GET. And the route is '/'.
 
 <br>
 So in the above example, when url will be - 
-* abc.com/user - method default will be called.
-* abc.com/getuser - method getuser will be called.
+
+* ```abc.com/user``` - method default will be called.
+* ```abc.com/user/:getuser``` - method getuser will be called.
 
 <br>
 ## How to declare a method as default worker without using decorator - defaultWorker

--- a/docs/tutorial/worker.md
+++ b/docs/tutorial/worker.md
@@ -54,15 +54,15 @@ Lets consider that controller - 'UserController' is associated with path '/user'
 
 So what these decorators - `Worker` and `DefaultWorker` do ?
 
-* **Worker** - method having decorator Worker is added to route with all http methods (GET,POST etc).And the route is ```'/${method_name}'. For our example - route will be : ```'/getuser'```.
+* **Worker** - method having decorator Worker is added to route with all http methods (GET,POST etc).And the route is '/${method_name}'. For our example - route will be : '/getuser'.
 
 * **DefaultWorker** - method having decorator DefaultWorker is added to route with one http method GET. And the route is '/'.
 
 <br>
 So in the above example, when url will be - 
 
-* ```abc.com/user``` - method default will be called.
-* ```abc.com/user/:getuser``` - method getuser will be called.
+* abc.com/user - method default will be called.
+* abc.com/user/:getuser - method getuser will be called.
 
 <br>
 ## How to declare a method as default worker without using decorator - defaultWorker


### PR DESCRIPTION
In the controller example, when we create UserController and assigned it to routes where you have bootstrapped our app, we specified the path as path: ```"/user".```

![Screenshot from 2019-09-16 15-09-11](https://user-images.githubusercontent.com/15966586/64950856-03185400-d89a-11e9-9553-95ab50f5dd0b.png)

But in the worked docs we have specified ```abc.com/getuser```. But it should also have the path ```/user```.

Hence modified ```abc.com/getuser``` to ```abc.com/user/getuser```
